### PR TITLE
feat: Add tests for PHP 8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2]
+        php: [8.1, 8.2, 8.3]
         laravel: [9, 10]
+        exclude:
+          - php: 8.3
+            laravel: 9
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 


### PR DESCRIPTION
This PR adds the test workflow for PHP 8.3. Laravel 9 with PHP 8.3 is excluded.