### PR TITLE
feat: Add support for Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,10 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [9, 10]
+        laravel: [9, 10, 11]
         exclude:
+          - php: 8.1
+            laravel: 11
           - php: 8.3
             laravel: 9
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,10 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [9, 10, 11]
+        laravel: [10, 11]
         exclude:
           - php: 8.1
             laravel: 11
-          - php: 8.3
-            laravel: 9
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,4 +51,4 @@ jobs:
           composer update --no-interaction --prefer-dist --no-progress
 
       - name: Execute tests
-        run: vendor/bin/pest --verbose
+        run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,16 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^9.21|^10.0|^11.0",
+        "illuminate/http": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0",
         "resend/resend-php": "^0.12.0",
         "symfony/mailer": "^6.2|^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.14",
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^7.37|^8.17|^9.0",
-        "pestphp/pest": "^1.22"
+        "orchestra/testbench": "^8.17|^9.0",
+        "pestphp/pest": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^9.21|^10.0",
+        "illuminate/support": "^9.21|^10.0|^11.0",
         "resend/resend-php": "^0.12.0",
-        "symfony/mailer": "^6.2"
+        "symfony/mailer": "^6.2|^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.14",
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^7.22|^8.0",
+        "orchestra/testbench": "^7.37|^8.17|^9.0",
         "pestphp/pest": "^1.22"
     },
     "autoload": {


### PR DESCRIPTION
This PR adds support for Laravel 11.x and drops support for Laravel 9.x (now considered end of life)