### PR TITLE
change: Throw TransportException instead of general Exception

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="vendor/autoload.php"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          colors="true"
          cacheDirectory=".phpunit.cache"
 >
@@ -10,9 +10,9 @@
             <directory suffix=".php">./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/Transport/ResendTransportFactory.php
+++ b/src/Transport/ResendTransportFactory.php
@@ -5,6 +5,7 @@ namespace Resend\Laravel\Transport;
 use Exception;
 use Resend\Contracts\Client;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Address;
@@ -70,8 +71,8 @@ class ResendTransportFactory extends AbstractTransport
                 'attachments' => $attachments,
             ]);
         } catch (Exception $exception) {
-            throw new Exception(
-                $exception->getMessage(),
+            throw new TransportException(
+                sprintf('Request to the Resend API failed. Reason: %s', $exception->getMessage()),
                 is_int($exception->getCode()) ? $exception->getCode() : 0,
                 $exception
             );

--- a/tests/Transport/ResendTransportFactory.php
+++ b/tests/Transport/ResendTransportFactory.php
@@ -6,6 +6,7 @@ use Resend\Contracts\Client;
 use Resend\Email;
 use Resend\Laravel\Transport\ResendTransportFactory;
 use Resend\Service\Email as EmailService;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email as SymfonyEmail;
 
@@ -164,10 +165,10 @@ it('can handle exceptions', function () {
     $this->client->emails
         ->shouldReceive('send')
         ->once()
-        ->andThrow(Exception::class);
+        ->andThrow(Exception::class, 'Failed');
 
     $this->transporter->send($email);
-})->throws(Exception::class);
+})->throws(TransportException::class, 'Request to the Resend API failed. Reason: Failed');
 
 it('can set the X-Resend-Email-ID', function () {
     $email = (new SymfonyEmail())


### PR DESCRIPTION
This PR changes the exception from `Exception` to `TransportException` to better identify the type of error that was caused.