### PR TITLE
feat: Add the ability to set attachment mime type

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -34,7 +34,7 @@ class WebhookController extends Controller
     {
         $payload = json_decode($request->getContent(), true);
 
-        if(is_null($payload) || !isset($payload['type'])) {
+        if (is_null($payload) || ! isset($payload['type'])) {
             return new Response('Invalid payload', 400);
         }
 

--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -13,7 +13,6 @@ class VerifyWebhookSignature
     /**
      * Handle an incoming request.
      *
-     * @param \Illuminate\Http\Request $request
      * @param \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response) $next
      */
     public function handle(Request $request, Closure $next)
@@ -37,18 +36,14 @@ class VerifyWebhookSignature
     /**
      * Transform headers to a simple associative array.
      * This method extracts the first value from each header and returns an array where each key is the header name and the associated value is that first header value
-     *
-     * @param \Illuminate\Http\Request $request
-     * @return array
      */
+    protected function getTransformedHeaders(Request $request): array
+    {
+        $headers = [];
+        foreach ($request->headers->all() as $key => $value) {
+            $headers[$key] = $value[0];
+        }
 
-     protected function getTransformedHeaders(Request $request): array
-     {
-         $headers = [];
-         foreach($request->headers->all() as $key => $value) {
-             $headers[$key] = $value[0];
-         }
-
-         return $headers;
-     }
+        return $headers;
+    }
 }

--- a/src/Transport/ResendTransportFactory.php
+++ b/src/Transport/ResendTransportFactory.php
@@ -51,6 +51,7 @@ class ResendTransportFactory extends AbstractTransport
                 $item = [
                     'content' => str_replace("\r\n", '', $attachment->bodyToString()),
                     'filename' => $filename,
+                    'content_type' => $headers->get('Content-Type')->getBody(),
                 ];
 
                 $attachments[] = $item;

--- a/tests/Http/Controllers/WebhookController.php
+++ b/tests/Http/Controllers/WebhookController.php
@@ -65,11 +65,12 @@ test('verify webhook signature middleware is called when webhook secret is set',
 });
 
 // This function creates a new Request object with a JSON body that does not include the fields expected by your controller.
-function invalidWebhookRequest() {
+function invalidWebhookRequest()
+{
     return new Illuminate\Http\Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['invalid' => 'data']));
 }
 
-test('it returns an error response for invalid payload', function() {
+test('it returns an error response for invalid payload', function () {
     $request = invalidWebhookRequest();
 
     $response = (new Controller)->handleWebhook($request);

--- a/tests/Transport/ResendTransportFactory.php
+++ b/tests/Transport/ResendTransportFactory.php
@@ -130,6 +130,7 @@ it('can send attachments', function () {
     $email->attach(
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean nunc augue, consectetur id neque eget, varius dignissim diam.',
         'lorem-ipsum.txt',
+        'text/plain'
     );
 
     $apiResponse = new Email([
@@ -146,8 +147,10 @@ it('can send attachments', function () {
                 ! empty($arg['attachments']) &&
                 array_key_exists('filename', $arg['attachments'][0]) &&
                 array_key_exists('content', $arg['attachments'][0]) &&
+                array_key_exists('content_type', $arg['attachments'][0]) &&
                 $arg['attachments'][0]['filename'] === 'lorem-ipsum.txt' &&
-                $arg['attachments'][0]['content'] === 'TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQWVuZWFuIG51bmMgYXVndWUsIGNvbnNlY3RldHVyIGlkIG5lcXVlIGVnZXQsIHZhcml1cyBkaWduaXNzaW0gZGlhbS4=';
+                $arg['attachments'][0]['content'] === 'TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQWVuZWFuIG51bmMgYXVndWUsIGNvbnNlY3RldHVyIGlkIG5lcXVlIGVnZXQsIHZhcml1cyBkaWduaXNzaW0gZGlhbS4=' &&
+                $arg['attachments'][0]['content_type'] === 'text/plain';
         }))
         ->andReturn($apiResponse);
 


### PR DESCRIPTION
This PR adds the ability to set the mime type for a mailable attachment using the new `content_type` parameter in the Resend email API.