### PR TITLE
feat: Add support for Contact Webhook Events

### DIFF
--- a/src/Events/ContactCreated.php
+++ b/src/Events/ContactCreated.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Resend\Laravel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ContactCreated
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new contact created event instance.
+     */
+    public function __construct(
+        public array $payload
+    ) {
+        //
+    }
+}

--- a/src/Events/ContactDeleted.php
+++ b/src/Events/ContactDeleted.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Resend\Laravel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ContactDeleted
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new contact deleted event instance.
+     */
+    public function __construct(
+        public array $payload
+    ) {
+        //
+    }
+}

--- a/src/Events/ContactUpdated.php
+++ b/src/Events/ContactUpdated.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Resend\Laravel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ContactUpdated
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new contact updated event instance.
+     */
+    public function __construct(
+        public array $payload
+    ) {
+        //
+    }
+}

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -5,6 +5,9 @@ namespace Resend\Laravel\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Str;
+use Resend\Laravel\Events\ContactCreated;
+use Resend\Laravel\Events\ContactDeleted;
+use Resend\Laravel\Events\ContactUpdated;
 use Resend\Laravel\Events\EmailBounced;
 use Resend\Laravel\Events\EmailClicked;
 use Resend\Laravel\Events\EmailComplained;
@@ -47,6 +50,36 @@ class WebhookController extends Controller
         }
 
         return $this->missingMethod($payload);
+    }
+
+    /**
+     * Handle contact created event.
+     */
+    protected function handleContactCreated(array $payload): Response
+    {
+        ContactCreated::dispatch($payload);
+
+        return $this->successMethod();
+    }
+
+    /**
+     * Handle contact deleted event.
+     */
+    protected function handleContactDeleted(array $payload): Response
+    {
+        ContactDeleted::dispatch($payload);
+
+        return $this->successMethod();
+    }
+
+    /**
+     * Handle contact updated event.
+     */
+    protected function handleContactUpdated(array $payload): Response
+    {
+        ContactUpdated::dispatch($payload);
+
+        return $this->successMethod();
     }
 
     /**

--- a/tests/Http/Controllers/WebhookController.php
+++ b/tests/Http/Controllers/WebhookController.php
@@ -1,6 +1,9 @@
 <?php
 
 use Illuminate\Support\Facades\Event;
+use Resend\Laravel\Events\ContactCreated;
+use Resend\Laravel\Events\ContactDeleted;
+use Resend\Laravel\Events\ContactUpdated;
 use Resend\Laravel\Events\EmailBounced;
 use Resend\Laravel\Events\EmailClicked;
 use Resend\Laravel\Events\EmailComplained;
@@ -26,6 +29,9 @@ test('correct methods are called and handled based on resend webhook event', fun
     expect($response->getStatusCode())->toBe(200)
         ->and($response->getContent())->toBe('Webhook handled');
 })->with([
+    ['contact.created', ContactCreated::class],
+    ['contact.deleted', ContactDeleted::class],
+    ['contact.updated', ContactUpdated::class],
     ['email.bounced', EmailBounced::class],
     ['email.clicked', EmailClicked::class],
     ['email.complained', EmailComplained::class],


### PR DESCRIPTION
This PR adds support for the new Contact related webhook events that were recently released: https://resend.com/changelog/new-contact-webhooks

This PR adds 3 new Laravel events to handle the new events as well as tests.