### PR TITLE
feat: Add support for Domain Webhook Events

### DIFF
--- a/src/Events/DomainCreated.php
+++ b/src/Events/DomainCreated.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Resend\Laravel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DomainCreated
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new domain created event instance.
+     */
+    public function __construct(
+        public array $payload
+    ) {
+        //
+    }
+}

--- a/src/Events/DomainDeleted.php
+++ b/src/Events/DomainDeleted.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Resend\Laravel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DomainDeleted
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new domain deleted event instance.
+     */
+    public function __construct(
+        public array $payload
+    ) {
+        //
+    }
+}

--- a/src/Events/DomainUpdated.php
+++ b/src/Events/DomainUpdated.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Resend\Laravel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DomainUpdated
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new domain updated event instance.
+     */
+    public function __construct(
+        public array $payload
+    ) {
+        //
+    }
+}

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -8,6 +8,9 @@ use Illuminate\Support\Str;
 use Resend\Laravel\Events\ContactCreated;
 use Resend\Laravel\Events\ContactDeleted;
 use Resend\Laravel\Events\ContactUpdated;
+use Resend\Laravel\Events\DomainCreated;
+use Resend\Laravel\Events\DomainDeleted;
+use Resend\Laravel\Events\DomainUpdated;
 use Resend\Laravel\Events\EmailBounced;
 use Resend\Laravel\Events\EmailClicked;
 use Resend\Laravel\Events\EmailComplained;
@@ -78,6 +81,36 @@ class WebhookController extends Controller
     protected function handleContactUpdated(array $payload): Response
     {
         ContactUpdated::dispatch($payload);
+
+        return $this->successMethod();
+    }
+
+    /**
+     * Handle domain created event.
+     */
+    protected function handleDomainCreated(array $payload): Response
+    {
+        DomainCreated::dispatch($payload);
+
+        return $this->successMethod();
+    }
+
+    /**
+     * Handle domain deleted event.
+     */
+    protected function handleDomainDeleted(array $payload): Response
+    {
+        DomainDeleted::dispatch($payload);
+
+        return $this->successMethod();
+    }
+
+    /**
+     * Handle domain updated event.
+     */
+    protected function handleDomainUpdated(array $payload): Response
+    {
+        DomainUpdated::dispatch($payload);
 
         return $this->successMethod();
     }

--- a/tests/Http/Controllers/WebhookController.php
+++ b/tests/Http/Controllers/WebhookController.php
@@ -4,6 +4,9 @@ use Illuminate\Support\Facades\Event;
 use Resend\Laravel\Events\ContactCreated;
 use Resend\Laravel\Events\ContactDeleted;
 use Resend\Laravel\Events\ContactUpdated;
+use Resend\Laravel\Events\DomainCreated;
+use Resend\Laravel\Events\DomainDeleted;
+use Resend\Laravel\Events\DomainUpdated;
 use Resend\Laravel\Events\EmailBounced;
 use Resend\Laravel\Events\EmailClicked;
 use Resend\Laravel\Events\EmailComplained;
@@ -32,6 +35,9 @@ test('correct methods are called and handled based on resend webhook event', fun
     ['contact.created', ContactCreated::class],
     ['contact.deleted', ContactDeleted::class],
     ['contact.updated', ContactUpdated::class],
+    ['domain.created', DomainCreated::class],
+    ['domain.deleted', DomainDeleted::class],
+    ['domain.updated', DomainUpdated::class],
     ['email.bounced', EmailBounced::class],
     ['email.clicked', EmailClicked::class],
     ['email.complained', EmailComplained::class],


### PR DESCRIPTION
This PR adds support for the new [Domain webhook events](https://resend.com/docs/dashboard/webhooks/event-types#domain-created).

- `domain.created` -> `DomainCreated`
- `domain.deleted` -> `DomainDeleted`
- `domain.updated` -> `DomainUpdated`