### PR TITLE
Fix: prevent headers being lost when attachments are added

### DIFF
--- a/src/Transport/ResendTransportFactory.php
+++ b/src/Transport/ResendTransportFactory.php
@@ -45,13 +45,13 @@ class ResendTransportFactory extends AbstractTransport
         $attachments = [];
         if ($email->getAttachments()) {
             foreach ($email->getAttachments() as $attachment) {
-                $headers = $attachment->getPreparedHeaders();
-                $filename = $headers->getHeaderParameter('Content-Disposition', 'filename');
+                $attachmentHeaders = $attachment->getPreparedHeaders();
+                $filename = $attachmentHeaders->getHeaderParameter('Content-Disposition', 'filename');
 
                 $item = [
                     'content' => str_replace("\r\n", '', $attachment->bodyToString()),
                     'filename' => $filename,
-                    'content_type' => $headers->get('Content-Type')->getBody(),
+                    'content_type' => $attachmentHeaders->get('Content-Type')->getBody(),
                 ];
 
                 $attachments[] = $item;


### PR DESCRIPTION
I noticed when using both custom headers and attachments my headers disappeared on the data being sent to the resend API. 
It seems the headers array is being overwritten bij the attachments loop. 