### PR TITLE
fix: skip encoding for ICS file attachments

### DIFF
--- a/src/Transport/ResendTransportFactory.php
+++ b/src/Transport/ResendTransportFactory.php
@@ -46,12 +46,20 @@ class ResendTransportFactory extends AbstractTransport
         if ($email->getAttachments()) {
             foreach ($email->getAttachments() as $attachment) {
                 $attachmentHeaders = $attachment->getPreparedHeaders();
+                $contentType = $attachmentHeaders->get('Content-Type')->getBody();
+
                 $filename = $attachmentHeaders->getHeaderParameter('Content-Disposition', 'filename');
 
+                if ($contentType == 'text/calendar') {
+                    $content = $attachment->getBody();
+                } else {
+                    $content = str_replace("\r\n", '', $attachment->bodyToString());
+                }
+
                 $item = [
-                    'content' => str_replace("\r\n", '', $attachment->bodyToString()),
+                    'content_type' => $contentType,
+                    'content' => $content,
                     'filename' => $filename,
-                    'content_type' => $attachmentHeaders->get('Content-Type')->getBody(),
                 ];
 
                 $attachments[] = $item;


### PR DESCRIPTION
This PR updates the ResendTrasportFactory to skip encoding of `text/calendar` file attachments. This fixes an issue where ICS files aren't correctly formatted when delivered to an email inbox.