### PR TITLE
Remove outdated PHP version warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 Provides Resend integration for Laravel and Symfony Mailer.
 
-> **Requires [PHP 8.1+](https://php.net/releases/)**
-
 ## Examples
 
 Send an email with:


### PR DESCRIPTION
Description
---
Since Laravel requires PHP 8.2+ as a minimal version to work, the PHP 8.1 warning is now obsolete and potentially confusing.