### PR TITLE
feat: add support for inline attachments

### DIFF
--- a/src/Transport/ResendTransportFactory.php
+++ b/src/Transport/ResendTransportFactory.php
@@ -46,12 +46,20 @@ class ResendTransportFactory extends AbstractTransport
         if ($email->getAttachments()) {
             foreach ($email->getAttachments() as $attachment) {
                 $attachmentHeaders = $attachment->getPreparedHeaders();
+                $contentType = $attachmentHeaders->get('Content-Type')->getBody();
+
                 $filename = $attachmentHeaders->getHeaderParameter('Content-Disposition', 'filename');
 
+                if ($contentType == 'text/calendar') {
+                    $content = $attachment->getBody();
+                } else {
+                    $content = str_replace("\r\n", '', $attachment->bodyToString());
+                }
+
                 $item = [
-                    'content' => str_replace("\r\n", '', $attachment->bodyToString()),
+                    'content_type' => $contentType,
+                    'content' => $content,
                     'filename' => $filename,
-                    'content_type' => $attachmentHeaders->get('Content-Type')->getBody(),
                 ];
 
                 $attachments[] = $item;

--- a/src/Transport/ResendTransportFactory.php
+++ b/src/Transport/ResendTransportFactory.php
@@ -105,7 +105,7 @@ class ResendTransportFactory extends AbstractTransport
                 ];
 
                 if ($disposition === 'inline') {
-                    $item['inline_content_id'] = 'cid:' . ($attachment->hasContentId() ? $attachment->getContentId() : $filename);
+                    $item['inline_content_id'] = $attachment->hasContentId() ? $attachment->getContentId() : $filename;
                 }
 
                 $attachments[] = $item;

--- a/tests/Transport/ResendTransportFactory.php
+++ b/tests/Transport/ResendTransportFactory.php
@@ -157,6 +157,45 @@ it('can send attachments', function () {
     $this->transporter->send($email);
 });
 
+it('can send inline attachments', function () {
+    $email = (new SymfonyEmail())
+        ->from('from@example.com')
+        ->to(new Address('to@example.com', 'Acme'))
+        ->subject('Test Subject')
+        ->text('Test plain text body');
+
+    $email->embed(
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean nunc augue, consectetur id neque eget, varius dignissim diam.',
+        'lorem-ipsum.txt',
+        'text/plain'
+    );
+
+    $apiResponse = new Email([
+        'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
+    ]);
+
+    $this->client->emails
+        ->shouldReceive('send')
+        ->once()
+        ->with(Mockery::on(function ($arg) {
+            return $arg['from'] === 'from@example.com' &&
+                $arg['to'] === ['"Acme" <to@example.com>'] &&
+                $arg['subject'] === 'Test Subject' &&
+                ! empty($arg['attachments']) &&
+                array_key_exists('filename', $arg['attachments'][0]) &&
+                array_key_exists('content', $arg['attachments'][0]) &&
+                array_key_exists('inline_content_id', $arg['attachments'][0]) &&
+                array_key_exists('content_type', $arg['attachments'][0]) &&
+                $arg['attachments'][0]['filename'] === 'lorem-ipsum.txt' &&
+                $arg['attachments'][0]['content'] === 'TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQWVuZWFuIG51bmMgYXVndWUsIGNvbnNlY3RldHVyIGlkIG5lcXVlIGVnZXQsIHZhcml1cyBkaWduaXNzaW0gZGlhbS4=' &&
+                $arg['attachments'][0]['inline_content_id'] === 'cid:lorem-ipsum.txt' &&
+                $arg['attachments'][0]['content_type'] === 'text/plain';
+        }))
+        ->andReturn($apiResponse);
+
+    $this->transporter->send($email);
+});
+
 it('can send calendar attachements', function () {
     $email = (new SymfonyEmail())
         ->from('from@example.com')

--- a/tests/Transport/ResendTransportFactory.php
+++ b/tests/Transport/ResendTransportFactory.php
@@ -188,7 +188,7 @@ it('can send inline attachments', function () {
                 array_key_exists('content_type', $arg['attachments'][0]) &&
                 $arg['attachments'][0]['filename'] === 'lorem-ipsum.txt' &&
                 $arg['attachments'][0]['content'] === 'TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQWVuZWFuIG51bmMgYXVndWUsIGNvbnNlY3RldHVyIGlkIG5lcXVlIGVnZXQsIHZhcml1cyBkaWduaXNzaW0gZGlhbS4=' &&
-                $arg['attachments'][0]['inline_content_id'] === 'cid:lorem-ipsum.txt' &&
+                $arg['attachments'][0]['inline_content_id'] === 'lorem-ipsum.txt' &&
                 $arg['attachments'][0]['content_type'] === 'text/plain';
         }))
         ->andReturn($apiResponse);


### PR DESCRIPTION
This PR adds support for inline attachments when using the Laravel Mailer. While this is automatically all handled within Laravel this PR simply ensures the correct request parameters are passed for inline attachments.