### PR TITLE
feat: add middleware group

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,11 @@ Finally, update the `MAIL_MAILER` environment variable to use `resend`:
 ```ini
 MAIL_MAILER=resend
 ```
+
+### Configuration
+
+You can optionally publish the configuration files to customize the package settings:
+
+```sh
+php artisan vendor:publish --tag=resend-config
+```

--- a/config/resend.php
+++ b/config/resend.php
@@ -69,4 +69,15 @@ return [
         'tolerance' => env('RESEND_WEBHOOK_TOLERANCE', 300),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | The list of middlewares that will be assigned to the webhook route.
+    |
+    */
+
+    'middleware' => []
+
 ];

--- a/src/ResendServiceProvider.php
+++ b/src/ResendServiceProvider.php
@@ -78,6 +78,7 @@ class ResendServiceProvider extends ServiceProvider
             'namespace' => 'Resend\Laravel\Http\Controllers',
             'prefix' => config('resend.path'),
             'as' => 'resend.',
+            'middleware' => config('resend.middleware', []),
         ], function () {
             $this->loadRoutesFrom(__DIR__ . '/../routes/web.php');
         });


### PR DESCRIPTION
This adds the ability to add a middleware group to the routes, like the `web` middleware.

The [documentation](https://resend.com/docs/send-with-laravel#csrf-protection) explains the "Webhook requests from Resend need to bypass Laravel’s CSRF protection", although the `web` middleware is not used currently, to no CSRF protection is added to the webhook route!